### PR TITLE
Fix build on POSIX based systems.

### DIFF
--- a/anyk-19kata/Dockerfile
+++ b/anyk-19kata/Dockerfile
@@ -6,5 +6,3 @@ RUN wget https://www.nav.gov.hu/data/cms489660/NAV_19KATA.jar -P ~ \
     # -s: silent (non-gui) install
     && java -jar ~/NAV_19KATA.jar -s \
     && rm ~/NAV_19KATA.jar
-
-RUN chmod +x /usr/bin/docker-entrypoint.sh

--- a/anyk-19kata/Dockerfile
+++ b/anyk-19kata/Dockerfile
@@ -6,3 +6,5 @@ RUN wget https://www.nav.gov.hu/data/cms489660/NAV_19KATA.jar -P ~ \
     # -s: silent (non-gui) install
     && java -jar ~/NAV_19KATA.jar -s \
     && rm ~/NAV_19KATA.jar
+
+RUN chmod +x /usr/bin/docker-entrypoint.sh

--- a/anyk/Dockerfile
+++ b/anyk/Dockerfile
@@ -19,3 +19,5 @@ RUN echo "root:root" | chpasswd \
     # -u: create user settings
     && java -jar ~/abevjava_install.jar -s -u \
     && rm ~/abevjava_install.jar
+
+RUN chmod +x /usr/bin/docker-entrypoint.sh


### PR DESCRIPTION
On POSIX based systems, the file permissions of the entry point script are preserved on copying. Sometimes this causes the file to be unexecutable. This PR adds an explicit execute permission to the file.