### PR TITLE
Fix default desktop panel configuration

### DIFF
--- a/anyk/files/docker-entrypoint.sh
+++ b/anyk/files/docker-entrypoint.sh
@@ -60,5 +60,7 @@ uuidgen > /etc/machine-id
 # set keyboard for all sh users
 echo "export QT_XKB_CONFIG_ROOT=/usr/share/X11/locale" >> /etc/profile
 
+# Use default desktop panel configuration
+mv /etc/xdg/xfce4/panel/default.xml /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
 
 exec "$@"


### PR DESCRIPTION
This fix sets the default panel configuration, so the user doesn't have to manually select it. If the other option is chosen, it results in an empty desktop.