### PR TITLE
Refactor build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
         base: ["base"]
 
     runs-on: ubuntu-latest
+
+    env:
+      DESKTOP: ${{ matrix.desktop }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -30,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build the ${{ matrix.base }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/${{ matrix.base }}.yml --env-file builds/env/${{ matrix.desktop }}.env build
+        run: docker buildx bake -f builds/${{ matrix.base }}.yml
 
   build-plugins:
     needs: build-base
@@ -40,6 +44,10 @@ jobs:
         plugin: ["NAV_19HIPA", "NAV_20HIPA", "NAV_21HIPA", "NAV_22HIPAK", "NAV_IGAZOL", "OEP_egt_tagallam", "OEP_igenylolap_eu_kartyahoz"]
 
     runs-on: ubuntu-latest
+
+    env:
+      DESKTOP: ${{ matrix.desktop }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -53,4 +61,4 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build the ${{ matrix.plugin }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/plugin/${{ matrix.plugin }}.yml --env-file builds/env/${{ matrix.desktop }}.env build
+        run: docker buildx bake -f builds/plugin/${{ matrix.plugin }}.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ jobs:
         base: ["base"]
 
     runs-on: ubuntu-latest
+
+    env:
+      DESKTOP: ${{ matrix.desktop }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -32,11 +36,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build the ${{ matrix.base }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/${{ matrix.base }}.yml --env-file builds/env/${{ matrix.desktop }}.env build
-
-      - name: Publish the ${{ matrix.base }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/${{ matrix.base }}.yml --env-file builds/env/${{ matrix.desktop }}.env push
+      - name: Build and publish the ${{ matrix.base }} ${{ matrix.desktop }} image
+        run: docker buildx bake -f builds/${{ matrix.base }}.yml --push
 
   build-plugins:
     needs: build-base
@@ -46,6 +47,10 @@ jobs:
         plugin: ["NAV_19HIPA", "NAV_20HIPA", "NAV_21HIPA", "NAV_22HIPAK", "NAV_IGAZOL", "OEP_egt_tagallam", "OEP_igenylolap_eu_kartyahoz"]
 
     runs-on: ubuntu-latest
+
+    env:
+      DESKTOP: ${{ matrix.desktop }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -65,11 +70,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build the ${{ matrix.plugin }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/plugin/${{ matrix.plugin }}.yml --env-file builds/env/${{ matrix.desktop }}.env build
-
-      - name: Publish the ${{ matrix.plugin }} ${{ matrix.desktop }} image
-        run: docker compose -f builds/plugin/${{ matrix.plugin }}.yml --env-file builds/env/${{ matrix.desktop }}.env push
+      - name: Build and publish the ${{ matrix.plugin }} ${{ matrix.desktop }} image
+        run: docker buildx bake -f builds/plugin/${{ matrix.plugin }}.yml --push
 
   update-readme:
     needs: [build-base, build-plugins]

--- a/builds/base.yml
+++ b/builds/base.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/Dockerfile
       args:
         DESKTOP: ${DESKTOP}
         BASE_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvany_apeh/keretprogramok/AbevJava

--- a/builds/env/kde.env
+++ b/builds/env/kde.env
@@ -1,1 +1,0 @@
-DESKTOP="kde"

--- a/builds/env/mate.env
+++ b/builds/env/mate.env
@@ -1,1 +1,0 @@
-DESKTOP="mate"

--- a/builds/env/xfce.env
+++ b/builds/env/xfce.env
@@ -1,1 +1,0 @@
-DESKTOP="xfce"

--- a/builds/plugin/NAV_19HIPA.yml
+++ b/builds/plugin/NAV_19HIPA.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvanykitolto_programok_nav/19HIPA/NAV_19HIPA

--- a/builds/plugin/NAV_20HIPA.yml
+++ b/builds/plugin/NAV_20HIPA.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvanykitolto_programok_nav/20HIPA/NAV_20HIPA

--- a/builds/plugin/NAV_21HIPA.yml
+++ b/builds/plugin/NAV_21HIPA.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvanykitolto_programok_nav/21HIPA/NAV_21HIPA

--- a/builds/plugin/NAV_22HIPAK.yml
+++ b/builds/plugin/NAV_22HIPAK.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvanykitolto_programok_nav/22hipak/nav_22hipak

--- a/builds/plugin/NAV_IGAZOL.yml
+++ b/builds/plugin/NAV_IGAZOL.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://nav.gov.hu/pfile/programFile?path=/nyomtatvanyok/letoltesek/nyomtatvanykitolto_programok/nyomtatvanykitolto_programok_nav/igazol/NAV_igazol

--- a/builds/plugin/OEP_egt_tagallam.yml
+++ b/builds/plugin/OEP_egt_tagallam.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://www.neak.gov.hu/pfile/file?path=/nyomtatvanytar/nyomtatvanytar/emagyarorszag/NEAK_OEP_egt_tagallam_1_14&inline=true

--- a/builds/plugin/OEP_igenylolap_eu_kartyahoz.yml
+++ b/builds/plugin/OEP_igenylolap_eu_kartyahoz.yml
@@ -12,7 +12,9 @@ services:
       platforms:
         - 'linux/amd64'
         - 'linux/arm64'
-      dockerfile: Dockerfile.plugin
+      x-bake:
+        platforms: ['linux/amd64', 'linux/arm64']
+      dockerfile: builds/plugin/Dockerfile.plugin
       args:
         DESKTOP: ${DESKTOP}
         PLUGIN_URL: https://www.neak.gov.hu/pfile/file?path=/nyomtatvanytar/nyomtatvanytar/emagyarorszag/NEAK_igenylolap_eu_kartyahoz&inline=true


### PR DESCRIPTION
Switch from `docker compose build` to `docker buildx bake`, as it seems like multi-platform images are not tagged when the buildx engine is used with `docker compose build`